### PR TITLE
fix: header style in dark mode

### DIFF
--- a/pages/index.module.css
+++ b/pages/index.module.css
@@ -166,7 +166,8 @@
     grid-template-columns: 500px calc(100vw - 517px);
   }
 
-  .headerContainer {
+  .headerContainer,
+  .headerContainerDark {
     padding: 24px 48px 48px 48px;
   }
 


### PR DESCRIPTION
When turns the dark mode, on the media query `(max-width: 1500px)` in the header container styles is missing some padding in the dark mode (light is fine).

This commit fixed that (preview gif below)L

**Before**

![before](https://user-images.githubusercontent.com/6449655/122645212-8471da00-d143-11eb-99ee-f123c2e22467.gif)

**After**
![after](https://user-images.githubusercontent.com/6449655/122645220-8c317e80-d143-11eb-90e9-0be9ad39d4a7.gif)

