### PR TITLE
Added link for chain.infoURL to make it easier to learn more about each chain

### DIFF
--- a/components/chain/chain.js
+++ b/components/chain/chain.js
@@ -106,7 +106,11 @@ export default function Chain({ chain }) {
           height={ 28 }
           className={ classes.avatar }
         />
-        <Typography variant='h3' className={ classes.name } noWrap>{ chain.name }</Typography>
+        <Typography variant='h3' className={ classes.name } noWrap>
+          <a href={ chain.infoURL } target="_blank" rel="noreferrer">
+            { chain.name }
+          </a>
+        </Typography>
       </div>
       <div className={ classes.chainInfoContainer }>
         <div className={ classes.dataPoint }>


### PR DESCRIPTION
Hey, this is a small update that adds links to the infoURL data that's stored in the JSON file for each chain. This makes it easier to get info about the chain without needed to open up a new tab and type in the chain name. Now I can just click the chain name and I'm taken to the main site for the chain or it's block explorer. It just makes life a little easier and has been something that's been bothering me since I started using the site. 

Keep up the great work :+1: 