### PR TITLE
Incorporated Support for wallet_switchEthereumChain

### DIFF
--- a/components/chain/chain.js
+++ b/components/chain/chain.js
@@ -35,6 +35,7 @@ export default function Chain({ chain }) {
     return () => {
       stores.emitter.removeListener(ACCOUNT_CONFIGURED, accountConfigure)
     }
+
   }, [])
 
   const toHex = (num) => {
@@ -61,16 +62,21 @@ export default function Chain({ chain }) {
 
     window.web3.eth.getAccounts((error, accounts) => {
       window.ethereum.request({
-        method: 'wallet_addEthereumChain',
-        params: [params, accounts[0]],
+        method: 'wallet_switchEthereumChain',
+        params: [{ chainId: params.chainId }],
+      }).catch((error) => {
+        window.ethereum.request({
+          method: 'wallet_addEthereumChain',
+          params: [params, accounts[0]],
+        })
+        .then((result) => {
+          console.log(result)
+        })
+        .catch((error) => {
+          stores.emitter.emit(ERROR, error.message ? error.message : error)
+          console.log(error)
+        });
       })
-      .then((result) => {
-        console.log(result)
-      })
-      .catch((error) => {
-        stores.emitter.emit(ERROR, error.message ? error.message : error)
-        console.log(error)
-      });
     })
   }
 

--- a/components/chain/chain.js
+++ b/components/chain/chain.js
@@ -35,7 +35,6 @@ export default function Chain({ chain }) {
     return () => {
       stores.emitter.removeListener(ACCOUNT_CONFIGURED, accountConfigure)
     }
-
   }, [])
 
   const toHex = (num) => {


### PR DESCRIPTION
### Description 

[EIP-3326](https://github.com/ethereum/EIPs/pull/3326) introduced the ability to switch between existing networks, including default ones. 
This PR introduces this new feature by trying to switch to an existing network, if it exists, before resolving to add the network (the recommended method according to metamask - see https://docs.metamask.io/guide/rpc-api.html#other-rpc-methods).

ref https://github.com/antonnell/networklist-org/issues/38 and https://github.com/antonnell/networklist-org/issues/35

### Test Plan
Built the app, connected Metamask and tested successfully transitioning to multiple Ethereum test networks (Ropsten, Rinkeby) as well as adding new networks (e.g Expanse Network)
